### PR TITLE
Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0 a.o

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,11 +7,11 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.0",
-        "arm:tools/arm/mdk-toolbox":" ^1.0.0",
-        "arm:tools/kitware/cmake": "^3.28.4",
-        "arm:tools/ninja-build/ninja": "^1.12.0",
-        "arm:compilers/arm/armclang": "^6.22.0",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1"
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+        "arm:tools/arm/mdk-toolbox":" ^1.1.0",
+        "arm:tools/kitware/cmake": "^3.31.5",
+        "arm:tools/ninja-build/ninja": "^1.12.1",
+        "arm:compilers/arm/armclang": "^6.24.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1"
     }
 }

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,13 +62,13 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
-          cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+          cp -a ./BSP/Examples/Blinky/. ./CI/Examples/Blinky/
 
       - name: Build Blinky AC6
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --update-rte --packs --toolchain AC6 --rebuild
+          cbuild ./Blinky.csolution.yml --packs --toolchain AC6 --rebuild
 
       - name: Upload Artifact of the Blinky AC6 build
         if: always()

--- a/Examples/Blinky/.cmsis/Blinky+STM32G071B-DISCO.dbgconf
+++ b/Examples/Blinky/.cmsis/Blinky+STM32G071B-DISCO.dbgconf
@@ -1,0 +1,39 @@
+// File: STM32G0x1.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32G0x1 reference manual (RM0444)
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.2>  DBG_STANDBY              <i> Debug Standby Mode
+//   <o.1>  DBG_STOP                 <i> Debug Stop Mode
+// </h>
+DbgMCU_CR = 0x00000006;
+
+// <h> Debug MCU APB freeze register 1 (DBGMCU_APB_FZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.31> DBG_LPTIM1_STOP          <i> LPTIMER1 counter stopped when core is halted
+//   <o.30> DBG_LPTIM2_STOP          <i> LPTIMER2 counter stopped when core is halted
+//   <o.21> DBG_I2C1_SMBUS_TIMEOUT   <i> I2C1 SMBUS timeout is frozen
+//   <o.12> DBG_IWDG_STOP            <i> Debug independent watchdog stopped when core is halted
+//   <o.11> DBG_WWDG_STOP            <i> Debug window watchdog stopped when core is halted
+//   <o.10> DBG_RTC_STOP             <i> Debug RTC stopped when core is halted
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 counter stopped when core is halted
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 counter stopped when core is halted
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 counter stopped when core is halted
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 counter stopped when core is halted
+// </h>
+DbgMCU_APB_Fz1 = 0x00000000;
+
+// <h> Debug MCU APB freeze register 2 (DBGMCU_APB_FZ2)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM17_STOP            <i> TIM17 counter stopped when core is halted
+//   <o.17> DBG_TIM16_STOP            <i> TIM16 counter stopped when core is halted
+//   <o.16> DBG_TIM15_STOP            <i> TIM15 counter stopped when core is halted
+//   <o.15> DBG_TIM14_STOP            <i> TIM14 counter stopped when core is halted
+//   <o.11> DBG_TIM1_STOP             <i> TIM1 counter stopped when core is halted
+// </h>
+DbgMCU_APB_Fz2 = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/.cmsis/Blinky+STM32G071B-DISCO.dbgconf.base@1.0.0
+++ b/Examples/Blinky/.cmsis/Blinky+STM32G071B-DISCO.dbgconf.base@1.0.0
@@ -1,0 +1,39 @@
+// File: STM32G0x1.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32G0x1 reference manual (RM0444)
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.2>  DBG_STANDBY              <i> Debug Standby Mode
+//   <o.1>  DBG_STOP                 <i> Debug Stop Mode
+// </h>
+DbgMCU_CR = 0x00000006;
+
+// <h> Debug MCU APB freeze register 1 (DBGMCU_APB_FZ1)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.31> DBG_LPTIM1_STOP          <i> LPTIMER1 counter stopped when core is halted
+//   <o.30> DBG_LPTIM2_STOP          <i> LPTIMER2 counter stopped when core is halted
+//   <o.21> DBG_I2C1_SMBUS_TIMEOUT   <i> I2C1 SMBUS timeout is frozen
+//   <o.12> DBG_IWDG_STOP            <i> Debug independent watchdog stopped when core is halted
+//   <o.11> DBG_WWDG_STOP            <i> Debug window watchdog stopped when core is halted
+//   <o.10> DBG_RTC_STOP             <i> Debug RTC stopped when core is halted
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 counter stopped when core is halted
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 counter stopped when core is halted
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 counter stopped when core is halted
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 counter stopped when core is halted
+// </h>
+DbgMCU_APB_Fz1 = 0x00000000;
+
+// <h> Debug MCU APB freeze register 2 (DBGMCU_APB_FZ2)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM17_STOP            <i> TIM17 counter stopped when core is halted
+//   <o.17> DBG_TIM16_STOP            <i> TIM16 counter stopped when core is halted
+//   <o.16> DBG_TIM15_STOP            <i> TIM15 counter stopped when core is halted
+//   <o.15> DBG_TIM14_STOP            <i> TIM14 counter stopped when core is halted
+//   <o.11> DBG_TIM1_STOP             <i> TIM1 counter stopped when core is halted
+// </h>
+DbgMCU_APB_Fz2 = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Keil.STM32G071B-DISCO_BSP.pdsc
+++ b/Keil.STM32G071B-DISCO_BSP.pdsc
@@ -21,7 +21,6 @@
       - rename thread IDs
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
-      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
       - add dbgconf files for the Blinky example.
       - updated RTE_Components.h file.	  
     </release>

--- a/Keil.STM32G071B-DISCO_BSP.pdsc
+++ b/Keil.STM32G071B-DISCO_BSP.pdsc
@@ -21,6 +21,9 @@
       - rename thread IDs
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
+      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
+      - add dbgconf files for the Blinky example.
+      - updated RTE_Components.h file.	  
     </release>
     <release version="1.0.0" date="2021-09-29">
       Board description and documentation for STM32G071B-DISCO


### PR DESCRIPTION
- Updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0.
- Added dbgconf files to the Blinky example.
- Updated workflow, RTE_Components.h, Blinky.csolution.yml, and Keil.STM32303E-EVAL_BSP.pdsc files.